### PR TITLE
Fix for using as a submodule

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,4 @@
+import sys,os
+sys.path.append(os.path.dirname(__file__))
+
 from .fluctana import *


### PR DESCRIPTION
Found a problem when using as a library (with a submodule). 
I think this is a non-invasive, backward compatible solution which can be used for both as a library (with a submodule) and with PYTHONPATH.